### PR TITLE
Fix the launching error in Mac

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -189,7 +189,7 @@ exports.configurePortable = function () {
 			return process.env['VSCODE_PORTABLE'];
 		}
 
-		if (process.platform === 'win32' || process.platform === 'linux') {
+		if (process.platform === 'win32' || process.platform === 'linux' || process.platform === 'darwin') {
 			return path.join(getApplicationPath(), 'data');
 		}
 


### PR DESCRIPTION
Otherwise it will throw the following error when launching
"TypeError: Path must be a string. Received true"